### PR TITLE
Implement nightly pipeline and Streamlit setup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,21 @@
+name: Nightly Data Update
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run nightly update
+        run: |
+          python scripts/nightly_update.py

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ Thumbs.db
 
 # Project specific
 *.html
-*.csv 
+*.csv

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[server]
+headless = true
+port = 8501
+enableCORS = false

--- a/README.md
+++ b/README.md
@@ -45,6 +45,33 @@ jupyter notebook
 
 The analysis uses sample financial data for demonstration purposes. In a production environment, this would be replaced with actual district financial data.
 
+## Automated Dashboard & Pipeline
+
+The repository includes a simple nightly pipeline that processes uploaded CSV files and stores the cleaned result in `data/processed/latest.csv`. Upload your raw files to `data/raw/` and the pipeline will pick up the most recent one.
+
+A GitHub Actions workflow (`.github/workflows/nightly.yml`) runs `scripts/nightly_update.py` every night at 2 AM UTC. It installs dependencies and processes the latest upload.
+
+To run the update locally:
+```bash
+python scripts/nightly_update.py
+```
+
+### Streamlit Configuration
+
+A basic Streamlit app (`src/dashboard.py`) can display the processed data. To use it, create the Streamlit configuration directory:
+```bash
+mkdir -p ~/.streamlit
+```
+Add a `config.toml` with your preferred settings, for example:
+```toml
+[server]
+headless = true
+```
+Run the dashboard with:
+```bash
+streamlit run src/dashboard.py
+```
+
 ## License
 
-MIT License 
+MIT License

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ scikit-learn>=1.3.0
 statsmodels>=0.14.0
 matplotlib==3.8.3
 seaborn==0.13.2
-scipy==1.12.0
+scipy>=1.12.0
 ipywidgets==8.1.2
-nbconvert==7.16.4 
+nbconvert==7.16.4
+streamlit>=1.32.0
+streamlit-option-menu>=0.3.0

--- a/scripts/nightly_update.py
+++ b/scripts/nightly_update.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.pipeline import run_nightly_update
+
+if __name__ == "__main__":
+    run_nightly_update()

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import streamlit as st
+from .utils.paths import get_data_path
+
+
+def run_dashboard() -> None:
+    processed_file = get_data_path("processed") / "latest.csv"
+    st.title("FLSD Financial Dashboard")
+    if processed_file.exists():
+        df = pd.read_csv(processed_file)
+        st.write("Latest processed data:")
+        st.dataframe(df.head())
+    else:
+        st.warning("No processed data found. Upload a CSV to data/raw and run the nightly update.")
+
+
+if __name__ == "__main__":
+    run_dashboard()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from pathlib import Path
+from .utils.paths import get_data_path
+
+
+def load_csv(path: Path) -> pd.DataFrame:
+    """Load a CSV file from the given path."""
+    return pd.read_csv(path)
+
+
+def clean_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Simple cleanup operations used by nightly pipeline."""
+    df = df.drop_duplicates()
+    return df.fillna(0)
+
+
+def save_processed(df: pd.DataFrame, name: str = "latest.csv") -> Path:
+    out_dir = get_data_path("processed")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / name
+    df.to_csv(out_file, index=False)
+    return out_file
+
+
+def run_nightly_update() -> None:
+    """Process the most recent uploaded CSV and store it as processed data."""
+    raw_dir = get_data_path("raw")
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    uploads = list(raw_dir.glob("*.csv"))
+    if not uploads:
+        print("No CSV uploads found in data/raw")
+        return
+    latest = max(uploads, key=lambda p: p.stat().st_mtime)
+    df = load_csv(latest)
+    processed = clean_data(df)
+    out_file = save_processed(processed)
+    print(f"Processed data saved to {out_file}")


### PR DESCRIPTION
## Summary
- add lightweight data pipeline in `src/pipeline.py`
- provide Streamlit dashboard runner
- script for nightly updates and scheduled GitHub Action
- update README with pipeline and Streamlit setup instructions
- refresh `.gitignore`

## Testing
- `python -m py_compile src/pipeline.py src/dashboard.py scripts/nightly_update.py`
- `python scripts/nightly_update.py`

------
https://chatgpt.com/codex/tasks/task_e_68423591e7048322bc6159229f477399