### PR TITLE
Fix circular import in streamlit wrapper

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import streamlit_app as st
+import streamlit as st
 import plotly.express as px
 import plotly.graph_objects as go
 from datetime import datetime


### PR DESCRIPTION
## Summary
- fix import in `src/dashboard.py` to use `streamlit` instead of the wrapper

## Testing
- `python -m py_compile streamlit_app.py src/dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68431b355e88832282ed052d4151d86c